### PR TITLE
Context management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 # venv
 venv/*
+__pycache__
+*tmp*
+.execution_context
+

--- a/README.md
+++ b/README.md
@@ -57,8 +57,6 @@ vnoremap <leader>sp :<C-u>call databricks#main(databricks#get_visual_selection()
 
 # Usage
 
-Currently everytime code is ran a new "execution context" is created then deleted. That means
-variables ran previously disappear. Therefore the best way to use vim-databricks, at the moment,
-is to run whole scripts. 
-
-Managing execution contexts will be the next released feature.
+Open a py script and execute <leader>sp on your keyboard. It will run any py command on the specified `g:databricks_cluster_id`.
+Every command and variable will be remembered through the execution context. To clear it and and reset the context run
+`:call databricks#clear_execution_context()`

--- a/autoload/databricks/databricks.vim
+++ b/autoload/databricks/databricks.vim
@@ -29,6 +29,11 @@ function! databricks#reopen_buffer(buf_num)
     execute "botright sb " . a:buf_num . " | resize " . buf_height
 endfunction
 
+function! databricks#clear_execution_context()
+    let l:file_path = s:plugin_path . 'databricks/.execution_context'
+    call delete(l:file_path)
+endfunction
+
 function! databricks#run_python(python_code)
     " Escape single quotes in the Python code
     let python_code_escaped = substitute(a:python_code, "'", "\\'", "g")

--- a/autoload/databricks/python_sdk.py
+++ b/autoload/databricks/python_sdk.py
@@ -2,6 +2,55 @@
 import argparse
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.service import compute
+import os
+from datetime import datetime
+
+def context_is_running(profile: str, cluster_id: str, context_id: str) -> bool:
+    """
+    Check if a context is running.
+
+    Parameters:
+        profile: str
+        cluster_id: str
+        context_id: str
+
+    Returns: 
+        bool
+    """
+    client = WorkspaceClient(profile=profile)
+    try:
+        res = client.command_execution.context_status(cluster_id, context_id)
+        return res.status.value == 'Running'
+    except Exception:
+        return False
+
+def get_execution_context(profile: str, cluster_id: str) -> str:
+    """
+    Get a new or old execution context. It starts to reading looking for a file at __file__/.execution_context . If one is
+    found it will check it is still running. Else it will create a new one.
+
+    Parameters:
+        profile: str
+        cluster_id: str
+
+    Returns: 
+        bool
+    
+    """
+    path = os.path.join(os.path.dirname(__file__), '.execution_context')
+    if os.path.exists(path):
+        with open(path, 'r') as f:
+            file = f.readlines()
+            id, last_time = file[-1].split(',')
+        if context_is_running(profile, cluster_id, id):
+            return id
+
+    cur_time = datetime.now()
+    client = WorkspaceClient(profile=profile)
+    new_context = client.command_execution.create(cluster_id=cluster_id, language=compute.Language.python).result()
+    with open(path, 'w') as f:
+        f.write(f'{new_context.id},{cur_time}')
+    return new_context.id
 
 def execute_code(cmd: str, profile: str, cluster_id: str) -> str:
     """
@@ -17,13 +66,11 @@ def execute_code(cmd: str, profile: str, cluster_id: str) -> str:
         str: command output
     """
     client = WorkspaceClient(profile=profile)
-    #cluster_id = '0420-160411-p8oi50n1'
-    context = client.command_execution.create(cluster_id=cluster_id, language=compute.Language.python).result()
+    context_id = get_execution_context(profile, cluster_id)
     response = client.command_execution.execute(cluster_id=cluster_id,
-                                                context_id=context.id,
+                                                context_id=context_id,
                                                 language=compute.Language.python,
                                                 command=cmd).result()
-    client.command_execution.destroy(cluster_id=cluster_id, context_id=context.id)
 
     return response.results.data
 
@@ -37,7 +84,9 @@ def main() -> None:
     parser.add_argument('--cluster_id')
     args = parser.parse_args()
 
+    #print(get_execution_context(args.profile, args.cluster_id))
     print(execute_code(args.code, args.profile, args.cluster_id))
 
 if __name__ == "__main__":
     main()
+

--- a/autoload/databricks/python_sdk.py
+++ b/autoload/databricks/python_sdk.py
@@ -72,7 +72,10 @@ def execute_code(cmd: str, profile: str, cluster_id: str) -> str:
                                                 language=compute.Language.python,
                                                 command=cmd).result()
 
-    return response.results.data
+    if response.results.cause:
+        return response.results.cause
+    else:
+        return response.results.data
 
 def main() -> None:
     """


### PR DESCRIPTION
Context can now be managed. A context id is written to `autoload/databricks/.execution_context`. It can be cleared by calling `:call databricks#clear_execution_context()`